### PR TITLE
wip

### DIFF
--- a/src/daggerml_cli/api.py
+++ b/src/daggerml_cli/api.py
@@ -303,7 +303,7 @@ def delete_cache(config, cache_key: Ref):
 
 def list_cache(config):
     with Cache(config.CACHE_PATH) as cache:
-        return list(cache)
+        return cache.list()
 
 
 def info_cache(config, cache_key: Ref):

--- a/src/daggerml_cli/cli/__init__.py
+++ b/src/daggerml_cli/cli/__init__.py
@@ -446,7 +446,8 @@ def cache_create(ctx):
 @clickex
 def cache_list(ctx):
     """List cached dags."""
-    click.echo(jsdumps(api.list_cache(ctx.obj)))
+    for item in api.list_cache(ctx.obj):
+        click.echo(jsdumps(item))
 
 
 @cache_group.command(name="info")

--- a/src/daggerml_cli/db.py
+++ b/src/daggerml_cli/db.py
@@ -121,7 +121,7 @@ class Cache:
 
         return self._resize_call(inner, write=True)
 
-    def __iter__(self):
+    def list(self):
         def inner(tx):
             with tx.cursor() as cursor:
                 return sorted(
@@ -129,7 +129,10 @@ class Cache:
                     key=lambda x: x["cache_key"],
                 )
 
-        return iter(self._resize_call(inner))
+        return self._resize_call(inner)
+
+    def __iter__(self):
+        return iter(self.list())
 
     def describe(self, key, val=None):
         val = val or self.get(key)

--- a/src/daggerml_cli/repo.py
+++ b/src/daggerml_cli/repo.py
@@ -800,12 +800,13 @@ class Repo:
             try:
                 result = BUILTIN_FNS[uri.path](*data)
             except Exception as e:
-                error = Error(e)
+                error = Error.from_ex(e)
             else:
                 result = self(Node(Literal(self.put_datum(result))))
                 nodes.append(result)
             fndag = self(FnDag(nodes, {}, result, error, argv_node))
         else:
+            assert self.cache_path, "cache path is required for function execution"
             with Cache(self.cache_path, create=False) as cache_db:
                 cached_val = cache_db.submit(fn, argv_datum.id, self.dump_ref(argv_datum))
             fndag = self.load_ref(cached_val) if cached_val else None
@@ -830,4 +831,4 @@ class Repo:
         commit = self.merge(self.get(self.head).commit, self(ctx.commit))
         self.set_head(self.head, commit)
         self.delete(index)
-        return self.dump_ref(ref)
+        return ref

--- a/tests/fn/sum.py
+++ b/tests/fn/sum.py
@@ -22,4 +22,4 @@ if __name__ == "__main__":
         except Exception as e:
             n0 = Error.from_ex(e)
         result = d0.commit(n0)
-        print(result)
+        print(d0.dump_ref(result))


### PR DESCRIPTION
Dag commit no longer returns with the full dump. Instead we return with just a ref, and the user is expected to call `dml ref dump %` on the resultant.

Also, cache listing is printed iteratively as jsonlines